### PR TITLE
Add 'extraEnv' 'service.annotations' and 'podAnnotations' parameters

### DIFF
--- a/deploy/cert-manager-webhook-selectel/Chart.yaml
+++ b/deploy/cert-manager-webhook-selectel/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
   - name: andrsp
     email: izotikov@selectel.ru
     url: https://github.com/andrsp
-version: 1.2.2
+version: 1.2.3

--- a/deploy/cert-manager-webhook-selectel/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-selectel/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ include "cert-manager-webhook-selectel.name" . }}
         release: {{ .Release.Name }}
@@ -31,6 +35,9 @@ spec:
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}
+          {{- with .Values.extraEnv }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: https
               containerPort: 443

--- a/deploy/cert-manager-webhook-selectel/templates/service.yaml
+++ b/deploy/cert-manager-webhook-selectel/templates/service.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cert-manager-webhook-selectel.fullname" . }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ include "cert-manager-webhook-selectel.name" . }}
     chart: {{ include "cert-manager-webhook-selectel.chart" . }}

--- a/deploy/cert-manager-webhook-selectel/values.yaml
+++ b/deploy/cert-manager-webhook-selectel/values.yaml
@@ -12,6 +12,8 @@ certManager:
   namespace: cert-manager
   serviceAccountName: cert-manager
 
+replicaCount: 1
+
 image:
   repository: ghcr.io/selectel/cert-manager-webhook-selectel
   tag: v1.2.0
@@ -20,9 +22,14 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+extraEnv: []
+# - name: SOME_VAR
+#   value: "some value"
+
 service:
   type: ClusterIP
   port: 443
+  annotations: {}
 
 resources: {}
 # limits:
@@ -31,6 +38,8 @@ resources: {}
 # requests:
 #  cpu: 100m
 #  memory: 128Mi
+
+podAnnotations: {}
 
 nodeSelector: {}
 


### PR DESCRIPTION
Hi,

We're expiriencing lack of customization using this chart.
Especially in the pod envs section and annotations.

This pull request brings flexibility in a few ways:
- `extraEnv` - a list of additional environment variables for the pod
- `podAnnotations` - a map of additional pod annotations
- `service.annotations` - a map of additional service annotations
- a missing `replicaCount` field added to the `values.yaml` file