### PR TITLE
feat: add AuthUrl param for servercore compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ spec:
             #   all times in seconds
             ttl: 120 # Default: 60
             timeout: 60 # Default 40
+            authUrl: "https://cloud.api.selcloud.ru/identity/v3"
 ```
 
 ### Issuing certificate

--- a/selectel/selectel.go
+++ b/selectel/selectel.go
@@ -31,6 +31,7 @@ type Config struct {
 	BaseURL           string            `json:"baseUrl"     validate:"required,gt=0"`
 	TTL               int               `json:"ttl"         validate:"required"`
 	HTTPTimeout       int               `json:"httpTimeout" validate:"required"`
+	AuthURL           string            `json:"authUrl"`    
 	CredentialsForDNS CredentialsForDNS `json:"-"`
 }
 
@@ -60,6 +61,7 @@ func NewConfigForDNS() (*Config, error) {
 		BaseURL:     defaultBaseURL,
 		TTL:         minTTL,
 		HTTPTimeout: defaultHTTPTimeout,
+		AuthURL:     "https://cloud.api.selcloud.ru/identity/v3", 
 	}
 
 	return cfg, nil
@@ -182,6 +184,7 @@ func getDNSClientFromConfig(config *Config) (domainsV2.DNSClient[domainsV2.Zone,
 		Username:   string(config.CredentialsForDNS.Username),
 		Password:   string(config.CredentialsForDNS.Password),
 		ProjectID:  string(config.CredentialsForDNS.ProjectID),
+		AuthURL:    config.AuthURL,
 	}
 
 	client, err := selvpcclient.NewClient(options)

--- a/selectel/selectel.go
+++ b/selectel/selectel.go
@@ -31,6 +31,7 @@ type Config struct {
 	BaseURL           string            `json:"baseUrl"     validate:"required,gt=0"`
 	TTL               int               `json:"ttl"         validate:"required"`
 	HTTPTimeout       int               `json:"httpTimeout" validate:"required"`
+	AuthRegion        string         	`json:"AuthRegion"`    
 	AuthURL           string            `json:"authUrl"`    
 	CredentialsForDNS CredentialsForDNS `json:"-"`
 }
@@ -61,6 +62,7 @@ func NewConfigForDNS() (*Config, error) {
 		BaseURL:     defaultBaseURL,
 		TTL:         minTTL,
 		HTTPTimeout: defaultHTTPTimeout,
+		AuthRegion: "uz-1"
 		AuthURL:     "https://cloud.api.selcloud.ru/identity/v3", 
 	}
 
@@ -185,6 +187,7 @@ func getDNSClientFromConfig(config *Config) (domainsV2.DNSClient[domainsV2.Zone,
 		Password:   string(config.CredentialsForDNS.Password),
 		ProjectID:  string(config.CredentialsForDNS.ProjectID),
 		AuthURL:    config.AuthURL,
+		AuthRegion:	config.AuthRegion,
 	}
 
 	client, err := selvpcclient.NewClient(options)

--- a/selectel/selectel.go
+++ b/selectel/selectel.go
@@ -31,7 +31,7 @@ type Config struct {
 	BaseURL           string            `json:"baseUrl"     validate:"required,gt=0"`
 	TTL               int               `json:"ttl"         validate:"required"`
 	HTTPTimeout       int               `json:"httpTimeout" validate:"required"`
-	AuthRegion        string         	`json:"AuthRegion"`    
+	AuthRegion        string         	`json:"authRegion"`    
 	AuthURL           string            `json:"authUrl"`    
 	CredentialsForDNS CredentialsForDNS `json:"-"`
 }
@@ -62,7 +62,7 @@ func NewConfigForDNS() (*Config, error) {
 		BaseURL:     defaultBaseURL,
 		TTL:         minTTL,
 		HTTPTimeout: defaultHTTPTimeout,
-		AuthRegion: "uz-1"
+		AuthRegion: "uz-1",
 		AuthURL:     "https://cloud.api.selcloud.ru/identity/v3", 
 	}
 


### PR DESCRIPTION
Overview

This pull request adds support for configuring the authentication URL for the Selectel DNS provider. It allows users to specify a custom identity endpoint for the Selectel API service, which is especially beneficial for users of ServerCore API or private cloud deployments.
Problem

Currently, the webhook hardcodes the auth URL (https://cloud.api.selcloud.ru/identity/v3) when initializing the selvpcclient. This presents a problem for users who need to connect to different instances of the Selectel API, such as ServerCore or other private cloud environments.
Solution

This PR adds:

    An authUrl field to the Config struct in selectel.go
    Sets a default value in NewConfigForDNS() for backward compatibility
    Passes this configuration to the selvpcclient.ClientOptions when creating the client
    Also adds necessary AuthRegion parameter that's required by the client library
